### PR TITLE
stg/ashu/Add country code field to Tailor entity and request classes 

### DIFF
--- a/src/main/java/com/darzee/shankh/dao/TailorDAO.java
+++ b/src/main/java/com/darzee/shankh/dao/TailorDAO.java
@@ -20,15 +20,17 @@ public class TailorDAO {
     private Language language;
     private TailorRole role;
     private String phoneNumber;
+    private String countryCode;
     private BoutiqueDAO boutique;
     private PortfolioDAO portfolio;
 
-    public TailorDAO(String name, TailorRole role, Language language, String phoneNumber, BoutiqueDAO boutique) {
+    public TailorDAO(String name, TailorRole role, Language language, String phoneNumber, BoutiqueDAO boutique,String countryCode) {
         this.name = name;
         this.role = role;
         this.language = language;
         this.boutique = boutique;
         this.phoneNumber = phoneNumber;
+        this.countryCode = countryCode;
     }
 
     public TailorDAO(String name, TailorRole role, Language language, String phoneNumber,

--- a/src/main/java/com/darzee/shankh/entity/Tailor.java
+++ b/src/main/java/com/darzee/shankh/entity/Tailor.java
@@ -34,6 +34,9 @@ public class Tailor extends GenericEntity {
     @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
 
+    @Column(name = "country_code", nullable = false)
+    private String countryCode;
+
     @OneToOne
     @JoinColumn(name = "boutique_id")
     private Boutique boutique;

--- a/src/main/java/com/darzee/shankh/repo/TailorRepo.java
+++ b/src/main/java/com/darzee/shankh/repo/TailorRepo.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 public interface TailorRepo extends JpaRepository<Tailor, Long>{
     Optional<Tailor> findByPhoneNumber(String phoneNumber);
 
+    Optional<Tailor> findByCountryCodeAndPhoneNumber(String countryCode, String phoneNumber);
+
     @Query(value = "SELECT name FROM tailor where id = :tailorId", nativeQuery = true)
     String findNameById(@Param("tailorId") Long tailorId);
 }

--- a/src/main/java/com/darzee/shankh/request/TailorLoginRequest.java
+++ b/src/main/java/com/darzee/shankh/request/TailorLoginRequest.java
@@ -17,4 +17,8 @@ public class TailorLoginRequest {
     @NotNull
     @Size(min=10, max=13, message = "Invalid phone number")
     private String phoneNumber;
+
+    @NotNull(message = "Country code is mandatory for app login")
+    @Size(min=1, max=3, message = "Invalid country code")
+    private String countryCode;
 }

--- a/src/main/java/com/darzee/shankh/request/TailorSignUpRequest.java
+++ b/src/main/java/com/darzee/shankh/request/TailorSignUpRequest.java
@@ -21,6 +21,10 @@ public class TailorSignUpRequest {
     @Size(min=10, max=10, message = "Invalid phone number")
     private String phoneNumber;
 
+    @NotNull(message = "Country code is mandatory for app sign up")
+    @Size(min=1, max=3, message = "Invalid country code")
+    private String countryCode;
+
     private Integer language;
 
     @JsonProperty("profile_pic_url")//todo : rename this variable to profile_pic_reference_id

--- a/src/main/java/com/darzee/shankh/utils/CommonUtils.java
+++ b/src/main/java/com/darzee/shankh/utils/CommonUtils.java
@@ -2,7 +2,9 @@ package com.darzee.shankh.utils;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -43,5 +45,17 @@ public class CommonUtils {
             return result;
         }
         return result;
+    }
+
+    public static Map<String, String> splitUsername(String username) {
+    String[] parts = username.split("\\+"); // assuming the country code is prefixed with '+'
+    String phoneNumber = parts[0];
+    String countryCode = "+" + parts[1];
+
+    Map<String, String> result = new HashMap<>();
+    result.put("phoneNumber", phoneNumber);
+    result.put("countryCode", countryCode);
+
+    return result;
     }
 }


### PR DESCRIPTION
This pull request adds a new field, `countryCode`, to the `Tailor` entity and request classes. The `countryCode` field is mandatory for app login and sign up, and it is used to store the country code of the phone number. This change ensures that the `countryCode` is included when querying for tailors by phone number and when loading a user by username in the `JwtUserDetailsService` class.